### PR TITLE
Added input data types for MAM4 and PartMC and related tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
-      - name: Setting up Python 3.10 (${{ matrix.os }})
+      - name: Setting up Python 3.12 (${{ matrix.os }})
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Installing ambrs dependencies (${{ matrix.os }})
         run: python3 -m pip install -r requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-ambrs/__pycache__
-test/__pycache__
+*/__pycache__
+*.pyc
 
 .DS_Store

--- a/ambrs/__init__.py
+++ b/ambrs/__init__.py
@@ -6,4 +6,5 @@ from .ppe import EnsembleSpecification, Ensemble, ensemble_from_scenarios, \
                  AerosolModeParameterSweeps, AerosolModalSizeParameterSweeps, \
                  AerosolParameterSweeps, sweep
 from .mam4 import MAM4Input, create_mam4_input, create_mam4_inputs
+from .partmc import PartMCInput, create_partmc_input, create_partmc_inputs
 from .scenario import Scenario

--- a/ambrs/__init__.py
+++ b/ambrs/__init__.py
@@ -5,5 +5,5 @@ from .ppe import EnsembleSpecification, Ensemble, ensemble_from_scenarios, \
                  sample, lhs, LinearParameterSweep, LogarithmicParameterSweep, \
                  AerosolModeParameterSweeps, AerosolModalSizeParameterSweeps, \
                  AerosolParameterSweeps, sweep
-from .mam4 import MAM4Input, create_mam4_inputs
+from .mam4 import MAM4Input, create_mam4_input, create_mam4_inputs
 from .scenario import Scenario

--- a/ambrs/aerosol.py
+++ b/ambrs/aerosol.py
@@ -21,7 +21,9 @@ class AerosolProcesses:
     # processes that can be enabled/disabled
     aging: bool = False
     coagulation: bool = False
+    condensation: bool = False
     mosaic: bool = False
+    optical: bool = False
     nucleation: bool = False
 
 @dataclass(frozen=True)

--- a/ambrs/aerosol.py
+++ b/ambrs/aerosol.py
@@ -9,7 +9,7 @@ import numpy as np
 import scipy.stats
 
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 # this type represents a frozen scipy.stats.rv_continous distribution
 # (this frozen type isn't made available by the scipy.stats package)
@@ -28,8 +28,9 @@ class AerosolProcesses:
 class AerosolSpecies:
     """AerosolSpecies: the definition of an aerosol species in terms of species-
 specific parameters (no state information)"""
-    name: str          # name of the species
-    molar_mass: float  # [g/mol]
+    name: str           # name of the species
+    molar_mass: float   # [g/mol]
+    aliases: Optional[tuple[str, ...]] = None # tuple of alternative species names
 
 #----------------------------
 # Modal aerosol descriptions

--- a/ambrs/gas.py
+++ b/ambrs/gas.py
@@ -1,6 +1,7 @@
 """ambrs.gas - Gas species related data types"""
 
 from dataclasses import dataclass
+from typing import Optional
 
 @dataclass(frozen=True)
 class GasSpecies:
@@ -8,3 +9,16 @@ class GasSpecies:
 specific parameters (no state information)"""
     name: str          # name of the species
     molar_mass: float  # [g/mol]
+    aliases: Optional[tuple[str, ...]] = None # tuple of alternative species names
+
+    @staticmethod
+    def find(species_list: list, species_name: str) -> int:
+        """GasSpecies.find(species_list, species_name) -> index of the gas species with the
+given name if found within the given list of GasSpecies, or -1 if not found.
+This function first tries to match the name of the species, and then tries to
+match any given aliases"""
+        for s, species in enumerate(species_list):
+            if species.name == species_name or \
+               (species.aliases and species_name in species.aliases):
+                return s
+        return -1

--- a/ambrs/mam4.py
+++ b/ambrs/mam4.py
@@ -133,7 +133,7 @@ file with the given name"""
         with open(filename, 'w') as f:
             f.write(content)
 
-def mam4_input_(processes: AerosolProcesses,
+def _mam4_input(processes: AerosolProcesses,
                 scenario: Scenario,
                 dt: float,
                 nstep: int) -> MAM4Input:
@@ -205,7 +205,7 @@ Parameters:
         raise ValueError("dt must be positive")
     if nstep <= 0:
         raise ValueError("nstep must be positive")
-    return mam4_input_(processes, scenario, dt, nstep)
+    return _mam4_input(processes, scenario, dt, nstep)
 
 def create_mam4_inputs(processes: AerosolProcesses,
                        ensemble: Ensemble,
@@ -229,5 +229,5 @@ Parameters:
         raise ValueError("nstep must be positive")
     inputs = []
     for scenario in ensemble:
-        inputs.append(mam4_input_(processes, scenario, dt, nstep))
+        inputs.append(_mam4_input(processes, scenario, dt, nstep))
     return inputs

--- a/ambrs/mam4.py
+++ b/ambrs/mam4.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .aerosol import AerosolProcesses, AerosolModalSizePopulation, \
                      AerosolModalSizeState
+from .gas import GasSpecies
 from .scenario import Scenario
 from .ppe import Ensemble
 
@@ -141,6 +142,15 @@ def _mam4_input(processes: AerosolProcesses,
         raise TypeError('Non-modal aerosol particle size state cannot be used to create MAM4 input!')
     if len(scenario.size.modes) != 4:
         raise TypeError(f'{len(scenario.size.mode)}-mode aerosol particle size state cannot be used to create MAM4 input!')
+    iso2 = GasSpecies.find(scenario.gases, 'so2')
+    if iso2 == -1:
+        raise ValueError("SO2 gas ('so2') not found in gas species")
+    ih2so4 = GasSpecies.find(scenario.gases, 'h2so4')
+    if ih2so4 == -1:
+        raise ValueError("H2SO4 gas ('h2so4') not found in gas species")
+    isoag = GasSpecies.find(scenario.gases, 'soag')
+    if isoag == -1:
+        raise ValueError("SOAG gas ('soag') not found in gas species")
     return MAM4Input(
         mam_dt = dt,
         mam_nstep = nstep,
@@ -181,10 +191,9 @@ def _mam4_input(processes: AerosolProcesses,
         mfpom4 = scenario.size.modes[3].mass_fraction("pom"),
         mfbc4  = scenario.size.modes[3].mass_fraction("bc"),
 
-        # FIXME: what to do about gases?
-        qso2 = 0,
-        qh2so4 = 0,
-        qsoag = 0,
+        qso2 = scenario.gas_concs[iso2],
+        qh2so4 = scenario.gas_concs[ih2so4],
+        qsoag = scenario.gas_concs[isoag],
      )
 
 def create_mam4_input(processes: AerosolProcesses,

--- a/ambrs/partmc.py
+++ b/ambrs/partmc.py
@@ -102,7 +102,7 @@ class PartMCInput:
     # process-specific fields`
     coag_kernel: Optional[str] = None # coagulation kernel name
 
-    def write_aero_modes_(self, prefix, modes):
+    def _write_aero_modes(self, prefix, modes):
         dist_file = f'{prefix}_dist.dat'
         with open(os.path.join(dir, dist_file)) as f:
             for i, mode in enumerate(modes):
@@ -242,7 +242,7 @@ files, with a main input <prefix>.spec file"""
             f.write('#\tdens (kg/m^3)\tions in soln (1)\tmolec wght (kg/mole)\tkappa (1)\n')
             for aero in self.aerosol_data:
                 f.write(f'{aero.species}\t{aero.density}\t{aero.ions_in_soln}\t{aero.molecular_weight}\t{aero.kappa}\n')
-        self.write_aero_modes_(f, 'aero_init', self.aerosol_init)
+        self._write_aero_modes(f, 'aero_init', self.aerosol_init)
 
         # temp.dat, pres.dat, height.dat
         with open(os.path.join(dir, 'temp.dat')) as f:
@@ -285,7 +285,7 @@ files, with a main input <prefix>.spec file"""
             f.write('\t'.join(['rate'] + [time_series[1]['rate'] for time_series in self.aero_emissions]))
             f.write('\t'.join(['dist'] + [f'aero_emit_dist_{i+1}.dat' for i in range(len(self.aero_emissions))]))
         for i, time_series in enumerate(self.aero_emissions):
-            self.write_aero_modes_(f'aero_emit_dist_{i+1}', self.aero_emissions)
+            self._write_aero_modes(f'aero_emit_dist_{i+1}', self.aero_emissions)
 
         # aero_back.dat, aero_back_dist.dat, aero_back_comp.dat
         with open(os.path.join(dir, 'aero_back.dat')) as f:
@@ -294,9 +294,9 @@ files, with a main input <prefix>.spec file"""
             f.write('\t'.join(['rate'] + [time_series[1]['rate'] for time_series in self.aero_background]))
             f.write('\t'.join(['dist'] + [f'aero_emit_dist_{i+1}.dat' for i in range(len(self.aero_background))]))
         for i, time_series in enumerate(self.aero_background):
-            self.write_aero_modes_(f'aero_back_dist_{i+1}', self.aero_background)
+            self._write_aero_modes(f'aero_back_dist_{i+1}', self.aero_background)
 
-def partmc_input_(processes: AerosolProcesses,
+def _partmc_input(processes: AerosolProcesses,
                   scenario: Scenario,
                   dt: float,
                   nstep: int) -> PartMCInput:
@@ -322,7 +322,7 @@ Parameters:
         raise ValueError("dt must be positive")
     if nstep <= 0:
         raise ValueError("nstep must be positive")
-    return partmc_input_(processes, scenario, dt, nstep)
+    return _partmc_input(processes, scenario, dt, nstep)
 
 def create_partmc_inputs(processes: AerosolProcesses,
                          ensemble: Ensemble,
@@ -346,5 +346,5 @@ Parameters:
         raise ValueError("nstep must be positive")
     inputs = []
     for scenario in ensemble:
-        inputs.append(partmc_input_(processes, scenario, dt, nstep))
+        inputs.append(_partmc_input(processes, scenario, dt, nstep))
     return inputs

--- a/ambrs/partmc.py
+++ b/ambrs/partmc.py
@@ -72,7 +72,6 @@ class PartMCInput:
     # in the .spec scenario file for the PartMC box model
 
     run_type: str               # particle, analytic, sectional
-    output_prefix: str          # prefix of output files
 
     restart:  bool              # whether to restart from saved state
     do_select_weighting: bool   # whether to select weighting explicitly
@@ -154,14 +153,15 @@ class PartMCInput:
                 for species, mass_frac in mode.mass_frac.items():
                     f.write(f'{species}\t{mass_frac}\n')
 
-    def write_files(self, dir):
-        """input.write_files(dir) -> writes a set of PartMC box model input
-files to the given directory"""
+    def write_files(self, dir, prefix):
+        """input.write_files(dir, prefix) -> writes a set of PartMC box model
+input files to the given directory with the given prefix for the main .spec
+file"""
         if not os.path.exists(dir):
             raise OSError(f'Directory not found: {dir}')
 
         # write the main (.spec) file
-        spec_content = f'run_type {self.run_type}\noutput_prefix {self.output_prefix}\n'
+        spec_content = f'run_type {self.run_type}\noutput_prefix {prefix}\n'
 
         if self.run_type == 'particle':
             spec_content += f'n_repeat {self.n_repeat}\nn_part {self.n_part}\n'
@@ -253,7 +253,7 @@ files to the given directory"""
         else:
             spec_content += 'do_parallel no\n'
 
-        with open(os.path.join(dir, self.output_prefix + '.spec'), 'w') as f:
+        with open(os.path.join(dir, prefix + '.spec'), 'w') as f:
             f.write(spec_content)
 
         # write auxiliary data files
@@ -342,7 +342,6 @@ def _partmc_input(run_type: str,
     aero_init = []
     return PartMCInput(
         run_type = run_type,
-        output_prefix = 'partmc', # FIXME: we need something better here
 
         restart = False,
         do_select_weighting = False,

--- a/ambrs/partmc.py
+++ b/ambrs/partmc.py
@@ -31,9 +31,9 @@ class PartMCAeroMode:
     log10_geom_std_dev: Optional[float] = None # log_10 of geometric std dev of diameter
 
 # time series data types
-type ScalarTimeSeries = tuple[tuple[float, float], ...] # tuple of (t, value) pairs
-type DictTimeSeries = tuple[tuple[float, dict], ...] # tuple of (t, dict) pairs
-type AerosolModeTimeSeries = tuple[tuple[float, PartMCAeroMode], ...] # tuple of (t, mode) pairs
+type ScalarTimeSeries = list[tuple[float, float], ...] # list of (t, value) pairs
+type DictTimeSeries = list[tuple[float, dict], ...] # list of (t, dict) pairs
+type AerosolModeTimeSeries = list[tuple[float, PartMCAeroMode], ...] # list of (t, mode) pairs
 
 @dataclass
 class PartMCInput:

--- a/ambrs/partmc.py
+++ b/ambrs/partmc.py
@@ -1,0 +1,242 @@
+"""ambrs.mam4 -- data types and functions related to the MAM4 box model"""
+
+from dataclasses import dataclass
+
+from .aerosol import AerosolProcesses, AerosolModalSizePopulation, \
+                     AerosolModalSizeState
+from .scenario import Scenario
+from .ppe import Ensemble
+from typing import Dict, Optional
+
+@dataclass
+class PartMCAeroData:
+    species: str            # name of aerosol species
+    density: float          # aerosol species density [kg/m^3]
+    ions_in_soln: int       # number of ions in solution [-]
+    molecular_weight: float # molecular weight [kg/mol]
+    kappa: float            # "kappa" [-]
+
+@dataclass
+class PartMCAeroDist:
+    mode_name: str              # name of aerosol mode
+    mass_frac: Dict[str, float] # mapping of modal species names to mass fractions
+    diam_type: str              # type of diameter specified (e.g. 'geometric')
+    mode_type: str              # type of distribution (e.g. 'log_normal')
+    num_conc: float             # modal number concentration [#/m^-3]
+
+    # geometric diameter parameters
+    geom_mean_diam: Optional[float] = None     # modal geometric mean diameter
+    log10_geom_std_dev: Optional[float] = None # log_10 of geometric std dev of diameter
+
+# time series data types
+type ScalarTimeSeries tuple[tuple[float, float], ...] # tuple of (t, value) pairs
+type CompositeTimeSeries tuple[tuple[float, dict], ...] # tuple of (t, dict) pairs
+
+@dataclass
+class PartMCInput:
+    """PartMCInput -- represents input for a single PartMC box model simulation"""
+    # all fields here are named identically to their respective parameters
+    # in the .spec scenario file for the PartMC box model
+
+    run_type: str               # particle, analytic, sectional
+    output_prefix: str          # prefix of output files
+
+    restart:  bool              # whether to restart from saved state
+    do_select_weighting: bool   # whether to select weighting explicitly
+
+    t_max: float                # total simulation time [s]
+    del_t: float                # timestep [s]
+    t_output: float             # output interval (0 disables) [s]
+    t_progress: float           # progress printing interval (0 disables) [s]
+
+    do_camp_chem: bool          # whether to use CAMP for chemistry
+
+    gas_data: tuple[str, ...]   # tuple of gas species names
+    gas_init: tuple[float, ...] # tuple of initial gas concentrations (in same
+                                # order as gas_data)
+
+    aerosol_data: tuple[PartMCAeroData, ...] # tuple of aerosol data
+    do_fractal: bool                         # whether to do fractal treatment
+    aerosol_init: tuple[PartMCAeroDist, ...] # aerosol initial condition file
+
+    temp_profile: ScalarTimeSeries       # temperature time series ((t1, T1), (t2, T2), ...)
+    pressure_profile: ScalarTimeSeries   # pressure time series
+    height_profile: ScalarTimeSeries     # height profile file
+    gas_emissions: CompositeTimeSeries   # gas emissions time series
+    gas_background: CompositeTimeSeries  # background gas concentration time series
+    aero_emissions: CompositeTimeSeries  # aerosol emissions file
+    aero_background: CompositeTimeSeries # aerosol background file
+
+    rel_humidity: float         # initial relative humidity [-]
+    latitude: float             # latitude [degrees, -90 to 90]
+    longitude: float            # longitude [degrees, -180 to 180]
+    altitude: float             # altitude [m]
+    start_time: int             # start time [s since 00:00 UTC]
+    start_day: int              # start day of year [days, UTC]
+
+    do_coagulation: bool        # whether to do coagulation
+    coag_kernel: str            # coagulation kernel name
+    do_condensation: bool       # whether to do condensation
+    do_mosaic: bool             # whether to do MOSAIC
+    do_optical: bool            # whether to compute optical props
+    do_nucleation: bool         # whether to do nucleation
+
+    rand_init: int              # random initialization (0 to use time)
+    allow_doubling: bool        # whether to allow doubling
+    allow_halving: bool         # whether to allow halving
+    record_removals: bool       # whether to record particle removals
+    do_parallel: bool           # whether to run in parallel
+
+    # particle-specific fields
+    n_repeat: Optional[int] = None # number of Monte Carlo repeats
+    n_part:   Optional[int] = None # number of particles
+    loss_function: Optional[str] = None # loss function specification
+    # TODO: analytic-specific fields??
+    # TODO: sectional-specific fields??
+    # TODO: fractal-specific fields??
+
+    def write_files(self, prefix):
+        """input.write_files(prefix) -> writes a set of PartMC box model input
+files, with a main input <prefix>.spec file"""
+        # write the main (.spec) file
+        spec_content = f'run_type {self.run_type}\noutput_prefix {self.output_prefix}\n'
+
+        if self.run_type == 'particle':
+            spec_content += f'n_repeat {self.n_repeat}\nn_part {self.n_part}\n'
+        if self.restart:
+            spec_content += 'restart yes\n'
+        else:
+            spec_content += 'restart no\n'
+        if self.do_select_weighting:
+            spec_content += 'do_select_weighting yes\n'
+        else:
+            spec_content += 'do_select_weighting no\n'
+
+        spec_content += f'\nt_max {self.t_max}\ndel_t {self.del_t}\nt_output {self.t_output}\nt_progress {self.t_progress}\n\n'
+
+        if self.do_camp_chem:
+            spec_content += 'do_camp_chem yes\n'
+        else:
+            spec_content += 'do_camp_chem no\n'
+
+        spec_content += '\ngas_data gas_data.dat\ngas_init gas_init.dat\n\n'
+
+        spec_content += 'aerosol_data aerosol_data.dat\n'
+        if self.do_fractal:
+            spec_content += 'do_fractal yes\n'
+        else:
+            spec_content += 'do_fractal no\n'
+        spec_content += 'aerosol_init aero_init_dist.dat\n\n'
+
+        spec_content += 'temp_profile temp.dat\npressure_profile pres.dat\nheight_profile height.dat\n'
+        spec_content += 'gas_emissions gas_emit.dat\ngas_background gas_back.dat\n'
+        spec_content += 'aero_emissions aero_emit.dat\naero_background aero_back.dat\n'
+        if self.loss_function:
+            spec_content += f'loss_function {self.loss_function}\n'
+        else:
+            spec_content += 'loss_function none\n'
+
+
+        with open(prefix + '.spec', 'w') as f:
+            f.write(spec_content)
+
+        # write auxiliary data files
+
+def mam4_input_(processes: AerosolProcesses,
+                scenario: Scenario,
+                dt: float,
+                nstep: int) -> MAM4Input:
+    if not isinstance(scenario.size, AerosolModalSizeState):
+        raise TypeError('Non-modal aerosol particle size state cannot be used to create MAM4 input!')
+    if len(scenario.size.modes) != 4:
+        raise TypeError(f'{len(scenario.size.mode)}-mode aerosol particle size state cannot be used to create MAM4 input!')
+    return MAM4Input(
+        mam_dt = dt,
+        mam_nstep = nstep,
+
+        mdo_gaschem = False,
+        mdo_gasaerexch = False,
+        mdo_rename = False,
+        mdo_newnuc = processes.nucleation,
+        mdo_coag = processes.coagulation,
+
+        temp = scenario.temperature,
+        press = scenario.pressure,
+        RH_CLEA = scenario.relative_humidity,
+
+        numc1 = scenario.size.modes[0].number,
+        numc2 = scenario.size.modes[1].number,
+        numc3 = scenario.size.modes[2].number,
+        numc4 = scenario.size.modes[3].number,
+
+        mfso41 = scenario.size.modes[0].mass_fraction("so4"),
+        mfpom1 = scenario.size.modes[0].mass_fraction("pom"),
+        mfsoa1 = scenario.size.modes[0].mass_fraction("soa"),
+        mfbc1  = scenario.size.modes[0].mass_fraction("bc"),
+        mfdst1 = scenario.size.modes[0].mass_fraction("dst"),
+        mfncl1 = scenario.size.modes[0].mass_fraction("ncl"),
+
+        mfso42 = scenario.size.modes[1].mass_fraction("so4"),
+        mfsoa2 = scenario.size.modes[1].mass_fraction("soa"),
+        mfncl2 = scenario.size.modes[1].mass_fraction("ncl"),
+
+        mfdst3 = scenario.size.modes[2].mass_fraction("dst"),
+        mfncl3 = scenario.size.modes[2].mass_fraction("ncl"),
+        mfso43 = scenario.size.modes[2].mass_fraction("so4"),
+        mfbc3  = scenario.size.modes[2].mass_fraction("bc"),
+        mfpom3 = scenario.size.modes[2].mass_fraction("pom"),
+        mfsoa3 = scenario.size.modes[2].mass_fraction("soa"),
+
+        mfpom4 = scenario.size.modes[3].mass_fraction("pom"),
+        mfbc4  = scenario.size.modes[3].mass_fraction("bc"),
+
+        # FIXME: what to do about gases?
+        qso2 = 0,
+        qh2so4 = 0,
+        qsoag = 0,
+     )
+
+def create_mam4_input(processes: AerosolProcesses,
+                      scenario: Scenario,
+                      dt: float,
+                      nstep: int) -> MAM4Input:
+    """create_mam4_input(processes, scenario, dt, nstep) -> MAM4Input object
+that can create a namelist input file for a MAM4 box model simulation
+
+Parameters:
+    * processes: an ambrs.AerosolProcesses object that defines the aerosol
+      processes under consideration
+    * scenario: an ambrs.Scenario object created by sampling a modal particle
+      size distribution
+    * dt: a fixed time step size for simulations
+    * nsteps: the number of steps in each simulation"""
+    if dt <= 0.0:
+        raise ValueError("dt must be positive")
+    if nstep <= 0:
+        raise ValueError("nstep must be positive")
+    return mam4_input_(processes, scenario, dt, nstep)
+
+def create_mam4_inputs(processes: AerosolProcesses,
+                       ensemble: Ensemble,
+                       dt: float,
+                       nstep: int) -> list[MAM4Input]:
+    """create_mam4_inputs(processes, ensemble, dt, nstep) -> list of MAM4Input
+objects that can create namelist input files for MAM4 box model simulations
+
+Parameters:
+    * processes: an ambrs.AerosolProcesses object that defines the aerosol
+      processes under consideration
+    * ensemble: a ppe.Ensemble object created by sampling a modal particle size
+      distribution
+    * dt: a fixed time step size for simulations
+    * nsteps: the number of steps in each simulation"""
+    if not isinstance(ensemble.size, AerosolModalSizePopulation):
+        raise TypeError("ensemble must have a modal size distribution!")
+    if dt <= 0.0:
+        raise ValueError("dt must be positive")
+    if nstep <= 0:
+        raise ValueError("nstep must be positive")
+    inputs = []
+    for scenario in ensemble:
+        inputs.append(mam4_input_(processes, scenario, dt, nstep))
+    return inputs

--- a/ambrs/ppe.py
+++ b/ambrs/ppe.py
@@ -331,10 +331,9 @@ parameter sweeps"""
     else:
         raise TypeError(f'sweep: Unsupported particle size representation: {reference_state.size.__class__}')
     if sweeps.gas_concs:
-        for i in range(len(sweeps.gas_concs[0])):
-            factors.append([c[i] for c in sweeps.gas_concs])
+        for gas_conc in sweeps.gas_concs:
+            factors.append([c for c in gas_conc])
     else:
-        print(reference_state.gas_concs)
         for c in range(len(reference_state.gas_concs)):
             factors.append([reference_state.gas_concs[c]])
     if sweeps.flux:

--- a/ambrs/ppe.py
+++ b/ambrs/ppe.py
@@ -18,6 +18,7 @@ from .aerosol import \
     AerosolModalSizeState, AerosolModeState, AerosolModePopulation, \
     AerosolModalSizeDistribution, AerosolModalSizePopulation, AerosolSpecies, \
     RVFrozenDistribution
+from .gas import GasSpecies
 from .scenario import Scenario
 
 @dataclass(frozen=True)
@@ -25,7 +26,10 @@ class EnsembleSpecification:
     """EnsembleSpecification: a set of distributions from which members of a
 PPE are sampled"""
     name: str
+    aerosols: tuple[AerosolSpecies, ...]
+    gases: tuple[GasSpecies, ...]
     size: AerosolModalSizeDistribution
+    gas_concs: tuple[RVFrozenDistribution, ...] # ordered like gases
     flux: RVFrozenDistribution
     relative_humidity: RVFrozenDistribution
     temperature: RVFrozenDistribution
@@ -36,7 +40,10 @@ PPE are sampled"""
 class Ensemble:
     """Ensemble: an ensemble defined by values sampled from the distributions of
 a specific EnsembleSpecification"""
+    aerosols: tuple[AerosolSpecies, ...]
+    gases: tuple[GasSpecies, ...]
     size: AerosolModalSizePopulation
+    gas_concs: tuple[np.array, ...] # ordered like gases
     flux: np.array
     relative_humidity: np.array
     temperature: np.array
@@ -54,7 +61,10 @@ a specific EnsembleSpecification"""
     def member(self, i: int) -> Scenario:
         """ensemble.member(i) -> extracts Scenario from ith ensemble member"""
         return Scenario(
+            aerosols = self.aerosols,
+            gases = self.gases,
             size = self.size.member(i),
+            gas_concs = tuple([conc[i] for conc in self.gas_concs]),
             flux = self.flux[i],
             relative_humidity = self.relative_humidity[i],
             temperature = self.temperature[i],
@@ -100,10 +110,16 @@ specified scenarios (which must all have the same particle size representation)"
         size = AerosolModalSizePopulation(
             modes = tuple(modes),
         )
-    if not size:
+    else:
         raise TypeError("Invalid particle size information in scenarios!")
+    gas_concs = []
+    for g in range(len(scenarios[0].gas_concs)):
+        gas_concs.append(np.array([scenario.gas_concs[g] for scenario in scenarios]))
     return Ensemble(
+        aerosols = scenarios[0].aerosols,
+        gases = scenarios[0].gases,
         size = size,
+        gas_concs = tuple(gas_concs),
         flux = flux,
         relative_humidity = relative_humidity,
         temperature = temperature,
@@ -134,8 +150,11 @@ def sample(specification: EnsembleSpecification, n: int) -> Ensemble:
             factor = sum([mass_fraction for mass_fraction in mode.mass_fractions])
             mode.mass_fractions = tuple([mf/factor for mf in mode.mass_fractions])
     return Ensemble(
+        aerosols = specification.aerosols,
+        gases = specification.gases,
         specification = specification,
         size = size,
+        gas_concs = tuple([gas_conc.rvs(n) for gas_conc in specification.gas_concs]),
         flux = specification.flux.rvs(n),
         relative_humidity = specification.relative_humidity.rvs(n),
         temperature = specification.temperature.rvs(n),
@@ -151,7 +170,8 @@ def lhs(specification: EnsembleSpecification,
 generated from latin hypercube sampling applied to the given specification. The
 optional arguments are passed along to pyDOE's lhs function, which creates the
 distribution from which ensemble members are sampled."""
-    n_factors = 3 # size-independent factors: flux + relative_humidity + temperature
+    num_gases = len(specification.gases)
+    n_factors = num_gases + 3 # size-independent factors: num_gases + flux + relative_humidity + temperature
     lhd = None # latin hypercube distribution (created depending on particle
                # size representation)
     size = None
@@ -178,9 +198,15 @@ distribution from which ensemble members are sampled."""
         for mode in size.modes:
             factor = sum([mass_fraction for mass_fraction in mode.mass_fractions])
             mode.mass_fractions = tuple([mf/factor for mf in mode.mass_fractions])
+    gas_concs = []
+    for g, gas_conc in enumerate(specification.gas_concs):
+        gas_concs.append(gas_conc.ppf(lhd[:,-3-(num_gases-g)]))
     return Ensemble(
+        aerosols = specification.aerosols,
+        gases = specification.gases,
         specification = specification,
         size = size,
+        gas_concs = tuple(gas_concs),
         flux = specification.flux.ppf(lhd[:,-3]),
         relative_humidity = specification.relative_humidity.ppf(lhd[:,-2]),
         temperature = specification.temperature.ppf(lhd[:,-1]),
@@ -258,6 +284,7 @@ If no sweep is specified for a given parameter, that parameter assumes a
 value specified by the reference_state passed to the sweep function.
 """
     size: Optional[AerosolModalSizeParameterSweeps] = None
+    gas_concs: Optional[tuple[LinearParameterSweep | LogarithmicParameterSweep, ...]] = None
     flux: Optional[LinearParameterSweep | LogarithmicParameterSweep] = None
     relative_humidity: Optional[LinearParameterSweep | LogarithmicParameterSweep] = None
     temperature: Optional[LinearParameterSweep | LogarithmicParameterSweep] = None
@@ -303,7 +330,13 @@ parameter sweeps"""
             factors = modal_size_factors(reference_state.size, sweeps.size)
     else:
         raise TypeError(f'sweep: Unsupported particle size representation: {reference_state.size.__class__}')
-
+    if sweeps.gas_concs:
+        for i in range(len(sweeps.gas_concs[0])):
+            factors.append([c[i] for c in sweeps.gas_concs])
+    else:
+        print(reference_state.gas_concs)
+        for c in range(len(reference_state.gas_concs)):
+            factors.append([reference_state.gas_concs[c]])
     if sweeps.flux:
         factors.append([F for F in sweeps.flux])
     else:
@@ -320,10 +353,11 @@ parameter sweeps"""
     # form all parameter combinations to populate an ensemble
     all_params = list(itertools.product(*factors))
     members = []
-    if isinstance(reference_state.size, AerosolModalSizeState):
-        for params in all_params:
+    for params in all_params:
+        index = 0
+        size = None
+        if isinstance(reference_state.size, AerosolModalSizeState):
             mode_states = []
-            index = 0
             for mode in reference_state.size.modes:
                 num_species = len(mode.species)
                 mass_fractions = [params[index+2+s] for s in range(num_species)]
@@ -337,19 +371,27 @@ parameter sweeps"""
                     ),
                 )
                 index += 2 + num_species
-            member = Scenario(
-                size = AerosolModalSizeState(
-                    modes = mode_states,
-                ),
-                flux = params[index],
-                relative_humidity = params[index + 1],
-                temperature = params[index + 2],
-                pressure = reference_state.pressure,
-                height = reference_state.height,
+            size = AerosolModalSizeState(
+                modes = mode_states,
             )
-            index += 3
-            members.append(member)
-    else:
-        raise TypeError(f'Unsupported particle size state: {reference_state.size.__class__}')
+        else:
+            raise TypeError(f'Unsupported particle size state: {reference_state.size.__class__}')
+        gas_concs = []
+        for g in range(len(reference_state.gas_concs)):
+            gas_concs.append(params[index + g])
+        index += len(gas_concs)
+        member = Scenario(
+            aerosols = reference_state.aerosols,
+            gases = reference_state.gases,
+            size = size,
+            gas_concs = tuple(gas_concs),
+            flux = params[index],
+            relative_humidity = params[index + 1],
+            temperature = params[index + 2],
+            pressure = reference_state.pressure,
+            height = reference_state.height,
+        )
+        index += 3
+        members.append(member)
 
     return ensemble_from_scenarios(members)

--- a/ambrs/scenario.py
+++ b/ambrs/scenario.py
@@ -13,4 +13,6 @@ in terms of state information"""
     flux: float
     relative_humidity: float
     temperature: float
+    pressure: float
+    height: float
 

--- a/ambrs/scenario.py
+++ b/ambrs/scenario.py
@@ -3,13 +3,18 @@ simulation scenarios.
 """
 
 from dataclasses import dataclass
-from .aerosol import AerosolModalSizeState
+from .aerosol import AerosolModalSizeState, AerosolSpecies
+from .gas import GasSpecies
+from typing import Dict
 
 @dataclass
 class Scenario:
     """Scenario: an abstract description of an aerosol configuration, expressed
 in terms of state information"""
-    size: AerosolModalSizeState # could also be sectional, stochastic, etc
+    aerosols: tuple[AerosolSpecies, ...] # aerosol species
+    gases: tuple[GasSpecies, ...]        # gas species
+    size: AerosolModalSizeState          # could also be sectional, stochastic, etc
+    gas_concs: tuple[float, ...]         # gas number concentrations (ordered like gases)
     flux: float
     relative_humidity: float
     temperature: float

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# This file configures CodeCov. New PRs can increase or decrease coverage--only
+# the total coverage threshold matters.
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+    patch: off # we can enable this if we figure out a reasonable policy
+

--- a/test/test_mam4.py
+++ b/test/test_mam4.py
@@ -160,6 +160,20 @@ class TestMAM4Input(unittest.TestCase):
         self.assertTrue(abs(scenario.size.modes[3].mass_fractions[0] - input.mfpom4) < 1e-12)
         self.assertTrue(abs(scenario.size.modes[3].mass_fractions[1] - input.mfbc4)  < 1e-12)
 
+        # test that passing invalid parameters raises exceptions appropriately
+        bad_scenario = scenario
+        bad_scenario.size = None
+        bad_args = [processes, bad_scenario, dt, nstep]
+        self.assertRaises(TypeError, mam4.create_mam4_input, *bad_args)
+
+        bad_dt = 0
+        bad_args = [processes, scenario, bad_dt, nstep]
+        self.assertRaises(ValueError, mam4.create_mam4_input, *bad_args)
+
+        bad_nstep = 0
+        bad_args = [processes, scenario, dt, bad_nstep]
+        self.assertRaises(ValueError, mam4.create_mam4_input, *bad_args)
+
     def test_create_mam4_inputs(self):
         processes = aerosol.AerosolProcesses(
             aging = True,
@@ -222,6 +236,30 @@ class TestMAM4Input(unittest.TestCase):
             self.assertEqual('primary carbon', scenario.size.modes[3].name)
             self.assertTrue(abs(scenario.size.modes[3].mass_fractions[0] - input.mfpom4) < 1e-12)
             self.assertTrue(abs(scenario.size.modes[3].mass_fractions[1] - input.mfbc4)  < 1e-12)
+
+        # test that passing invalid parameters raises exceptions appropriately
+        bad_ensemble = ppe.Ensemble(
+            aerosols = self.ensemble.aerosols,
+            gases = self.ensemble.gases,
+            size = None,
+            gas_concs = self.ensemble.gas_concs,
+            flux = self.ensemble.flux,
+            relative_humidity = self.ensemble.relative_humidity,
+            temperature = self.ensemble.temperature,
+            pressure = self.ensemble.pressure,
+            height = self.ensemble.height,
+            specification = self.ensemble.specification,
+        )
+        bad_args = [processes, bad_ensemble, dt, nstep]
+        self.assertRaises(TypeError, mam4.create_mam4_inputs, *bad_args)
+
+        bad_dt = 0
+        bad_args = [processes, self.ensemble, bad_dt, nstep]
+        self.assertRaises(ValueError, mam4.create_mam4_inputs, *bad_args)
+
+        bad_nstep = 0
+        bad_args = [processes, self.ensemble, dt, bad_nstep]
+        self.assertRaises(ValueError, mam4.create_mam4_inputs, *bad_args)
 
     def test_write_namelist(self):
         processes = aerosol.AerosolProcesses(

--- a/test/test_mam4.py
+++ b/test/test_mam4.py
@@ -35,6 +35,8 @@ class TestMAM4Input(unittest.TestCase):
         self.n = 100
         self.ensemble_spec = ppe.EnsembleSpecification(
             name = 'mam4_ensemble',
+            aerosols = (so4, pom, soa, bc, dst, ncl),
+            gases = (so2, h2so4, soag),
             size = aerosol.AerosolModalSizeDistribution(
                 modes = [
                     aerosol.AerosolModeDistribution(
@@ -88,6 +90,7 @@ class TestMAM4Input(unittest.TestCase):
                     ),
                 ],
             ),
+            gas_concs = (scipy.stats.loguniform(1e5, 1e6) for g in range(3)),
             flux = scipy.stats.loguniform(1e-2*1e-9, 1e1*1e-9),
             relative_humidity = scipy.stats.loguniform(1e-5, 0.99),
             temperature = scipy.stats.uniform(240, 310),

--- a/test/test_mam4.py
+++ b/test/test_mam4.py
@@ -1,0 +1,238 @@
+# unit tests for the ambrs.mam4 package
+
+import ambrs.aerosol as aerosol
+import ambrs.gas as gas
+import ambrs.ppe as ppe
+from ambrs.scenario import Scenario
+import ambrs.mam4 as mam4
+
+import math
+import numpy as np
+import os, os.path
+import scipy.stats
+import unittest
+
+# relevant aerosol and gas species
+so4 = aerosol.AerosolSpecies(name='so4', molar_mass = 97.071)
+pom = aerosol.AerosolSpecies(name='pom', molar_mass = 12.01)
+soa = aerosol.AerosolSpecies(name='soa', molar_mass = 12.01)
+bc  = aerosol.AerosolSpecies(name='bc', molar_mass = 12.01)
+dst = aerosol.AerosolSpecies(name='dst', molar_mass = 135.065)
+ncl = aerosol.AerosolSpecies(name='ncl', molar_mass = 58.44)
+
+so2   = gas.GasSpecies(name='so2', molar_mass = 64.07)
+h2so4 = gas.GasSpecies(name='h2so4', molar_mass = 98.079)
+soag  = gas.GasSpecies(name='soag', molar_mass = 12.01)
+
+# reference pressure and height
+p0 = 101325 # [Pa]
+h0 = 500    # [m]
+
+class TestMAM4Input(unittest.TestCase):
+    """Unit tests for ambr.mam4.MAM4Input"""
+
+    def setUp(self):
+        self.n = 100
+        self.ensemble_spec = ppe.EnsembleSpecification(
+            name = 'mam4_ensemble',
+            size = aerosol.AerosolModalSizeDistribution(
+                modes = [
+                    aerosol.AerosolModeDistribution(
+                        name = "accumulation",
+                        species = [so4, pom, soa, bc, dst, ncl],
+                        number = scipy.stats.loguniform(3e7, 2e12),
+                        geom_mean_diam = scipy.stats.loguniform(0.5e-7, 1.1e-7),
+                        mass_fractions = [
+                            scipy.stats.uniform(0, 1), # so4
+                            scipy.stats.uniform(0, 1), # pom
+                            scipy.stats.uniform(0, 1), # soa
+                            scipy.stats.uniform(0, 1), # bc
+                            scipy.stats.uniform(0, 1), # dst
+                            scipy.stats.uniform(0, 1), # ncl
+                        ],
+                    ),
+                    aerosol.AerosolModeDistribution(
+                        name = "aitken",
+                        species = [so4, soa, ncl],
+                        number = scipy.stats.loguniform(3e7, 2e12),
+                        geom_mean_diam = scipy.stats.loguniform(0.5e-8, 3e-8),
+                        mass_fractions = [
+                            scipy.stats.uniform(0, 1), # so4
+                            scipy.stats.uniform(0, 1), # soa
+                            scipy.stats.uniform(0, 1), # ncl
+                        ],
+                    ),
+                    aerosol.AerosolModeDistribution(
+                        name = "coarse",
+                        species = [dst, ncl, so4, bc, pom, soa],
+                        number = scipy.stats.loguniform(3e7, 2e12),
+                        geom_mean_diam = scipy.stats.loguniform(1e-6, 2e-6),
+                        mass_fractions = [
+                            scipy.stats.uniform(0, 1), # dst
+                            scipy.stats.uniform(0, 1), # ncl
+                            scipy.stats.uniform(0, 1), # so4
+                            scipy.stats.uniform(0, 1), # bc
+                            scipy.stats.uniform(0, 1), # pom
+                            scipy.stats.uniform(0, 1), # soa
+                        ],
+                    ),
+                    aerosol.AerosolModeDistribution(
+                        name = "primary carbon",
+                        species = [pom, bc],
+                        number = scipy.stats.loguniform(3e7, 2e12),
+                        geom_mean_diam = scipy.stats.loguniform(1e-8, 6e-8),
+                        mass_fractions = [
+                            scipy.stats.uniform(0, 1), # pom
+                            scipy.stats.uniform(0, 1), # bc
+                        ],
+                    ),
+                ],
+            ),
+            flux = scipy.stats.loguniform(1e-2*1e-9, 1e1*1e-9),
+            relative_humidity = scipy.stats.loguniform(1e-5, 0.99),
+            temperature = scipy.stats.uniform(240, 310),
+            pressure = p0,
+            height = h0,
+        )
+        self.ensemble = ppe.sample(self.ensemble_spec, self.n)
+
+    def test_create_mam4_input(self):
+        processes = aerosol.AerosolProcesses(
+            aging = True,
+            coagulation = True,
+        )
+        scenario = self.ensemble.member(0)
+        dt = 4.0
+        nstep = 100
+        input = mam4.create_mam4_input(processes, scenario, dt, nstep)
+
+        # timestepping parameters
+        self.assertTrue(abs(dt - input.mam_dt) < 1e-12)
+        self.assertTrue(nstep, input.mam_nstep)
+
+        # aerosol processes
+        self.assertFalse(input.mdo_gaschem)
+        self.assertFalse(input.mdo_gasaerexch)
+        self.assertFalse(input.mdo_rename)
+        self.assertFalse(input.mdo_newnuc)
+        self.assertTrue(input.mdo_coag)
+
+        # atmospheric conditions
+        self.assertTrue(abs(scenario.temperature - input.temp) < 1e-12)
+        self.assertTrue(abs(scenario.pressure - input.press) < 1e-12)
+        self.assertTrue(abs(scenario.relative_humidity - input.RH_CLEA) < 1e-12)
+
+        # modal number concentrations
+        self.assertTrue(abs(scenario.size.modes[0].number - input.numc1) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[1].number - input.numc2) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].number - input.numc3) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[3].number - input.numc4) < 1e-12)
+
+        # accumulation mode species mass fractions
+        self.assertEqual('accumulation', scenario.size.modes[0].name)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[0] - input.mfso41) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[1] - input.mfpom1) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[2] - input.mfsoa1) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[3] - input.mfbc1)  < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[4] - input.mfdst1) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[5] - input.mfncl1) < 1e-12)
+
+        # aitken mode species mass fractions
+        self.assertEqual('aitken', scenario.size.modes[1].name)
+        self.assertTrue(abs(scenario.size.modes[1].mass_fractions[0] - input.mfso42) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[1].mass_fractions[1] - input.mfsoa2) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[1].mass_fractions[2] - input.mfncl2) < 1e-12)
+
+        # coarse mode species mass fractions
+        self.assertEqual('coarse', scenario.size.modes[2].name)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[0] - input.mfdst3) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[1] - input.mfncl3) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[2] - input.mfso43) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[3] - input.mfbc3)  < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[4] - input.mfpom3) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[5] - input.mfsoa3) < 1e-12)
+
+        # primary carbon species mass fractions
+        self.assertEqual('primary carbon', scenario.size.modes[3].name)
+        self.assertTrue(abs(scenario.size.modes[3].mass_fractions[0] - input.mfpom4) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[3].mass_fractions[1] - input.mfbc4)  < 1e-12)
+
+    def test_create_mam4_inputs(self):
+        processes = aerosol.AerosolProcesses(
+            aging = True,
+            coagulation = True,
+        )
+        dt = 4.0
+        nstep = 100
+
+        inputs = mam4.create_mam4_inputs(processes, self.ensemble, dt, nstep)
+        for i, input in enumerate(inputs):
+            scenario = self.ensemble.member(i)
+
+            # timestepping parameters
+            self.assertTrue(abs(dt - input.mam_dt) < 1e-12)
+            self.assertTrue(nstep, input.mam_nstep)
+
+            # aerosol processes
+            self.assertFalse(input.mdo_gaschem)
+            self.assertFalse(input.mdo_gasaerexch)
+            self.assertFalse(input.mdo_rename)
+            self.assertFalse(input.mdo_newnuc)
+            self.assertTrue(True, input.mdo_coag)
+
+            # atmospheric conditions
+            self.assertTrue(abs(scenario.temperature - input.temp) < 1e-12)
+            self.assertTrue(abs(scenario.pressure - input.press) < 1e-12)
+            self.assertTrue(abs(scenario.relative_humidity - input.RH_CLEA) < 1e-12)
+
+            # modal number concentrations
+            self.assertTrue(abs(scenario.size.modes[0].number - input.numc1) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[1].number - input.numc2) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].number - input.numc3) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[3].number - input.numc4) < 1e-12)
+
+            # accumulation mode species mass fractions
+            self.assertEqual('accumulation', scenario.size.modes[0].name)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[0] - input.mfso41) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[1] - input.mfpom1) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[2] - input.mfsoa1) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[3] - input.mfbc1)  < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[4] - input.mfdst1) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[5] - input.mfncl1) < 1e-12)
+
+            # aitken mode species mass fractions
+            self.assertEqual('aitken', scenario.size.modes[1].name)
+            self.assertTrue(abs(scenario.size.modes[1].mass_fractions[0] - input.mfso42) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[1].mass_fractions[1] - input.mfsoa2) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[1].mass_fractions[2] - input.mfncl2) < 1e-12)
+
+            # coarse mode species mass fractions
+            self.assertEqual('coarse', scenario.size.modes[2].name)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[0] - input.mfdst3) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[1] - input.mfncl3) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[2] - input.mfso43) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[3] - input.mfbc3)  < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[4] - input.mfpom3) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[5] - input.mfsoa3) < 1e-12)
+
+            # primary carbon species mass fractions
+            self.assertEqual('primary carbon', scenario.size.modes[3].name)
+            self.assertTrue(abs(scenario.size.modes[3].mass_fractions[0] - input.mfpom4) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[3].mass_fractions[1] - input.mfbc4)  < 1e-12)
+
+    def test_write_namelist(self):
+        processes = aerosol.AerosolProcesses(
+            aging = True,
+            coagulation = True,
+        )
+        scenario = self.ensemble.member(0)
+        dt = 4.0
+        nstep = 100
+        input = mam4.create_mam4_input(processes, scenario, dt, nstep)
+        input_file = 'mam4_input.nl'
+        input.write_namelist(input_file)
+        self.assertTrue(os.path.exists(input_file))
+        os.remove(input_file)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_partmc.py
+++ b/test/test_partmc.py
@@ -159,7 +159,7 @@ class TestPartMCInput(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory()
         input.write_files(temp_dir.name)
         self.assertTrue(os.path.exists(os.path.join(temp_dir.name, 'partmc.spec')))
-        temp_dir.close()
+        temp_dir.cleanup()
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_partmc.py
+++ b/test/test_partmc.py
@@ -155,9 +155,8 @@ class TestPartMCInput(unittest.TestCase):
         dt = 4.0
         nstep = 100
         input = partmc.create_partmc_input('particle', processes, scenario, dt, nstep)
-        prefix = 'partmc'
         temp_dir = tempfile.TemporaryDirectory()
-        input.write_files(temp_dir.name)
+        input.write_files(temp_dir.name, 'partmc')
         self.assertTrue(os.path.exists(os.path.join(temp_dir.name, 'partmc.spec')))
         temp_dir.cleanup()
 

--- a/test/test_partmc.py
+++ b/test/test_partmc.py
@@ -108,58 +108,19 @@ class TestPartMCInput(unittest.TestCase):
         scenario = self.ensemble.member(0)
         dt = 4.0
         nstep = 100
-        input = partmc.create_partmc_input(processes, scenario, dt, nstep)
+        input = partmc.create_partmc_input('particle', processes, scenario, dt, nstep)
 
         # timestepping parameters
-        self.assertTrue(abs(dt - input.mam_dt) < 1e-12)
-        self.assertTrue(nstep, input.mam_nstep)
+        self.assertTrue(abs(dt - input.del_t) < 1e-12)
+        self.assertTrue(abs(nstep * dt - input.t_max) < 1e-12)
 
         # aerosol processes
-        self.assertFalse(input.mdo_gaschem)
-        self.assertFalse(input.mdo_gasaerexch)
-        self.assertFalse(input.mdo_rename)
-        self.assertFalse(input.mdo_newnuc)
-        self.assertTrue(input.mdo_coag)
+        self.assertFalse(input.do_mosaic)
+        self.assertFalse(input.do_nucleation)
+        self.assertFalse(input.do_condensation)
+        self.assertTrue(input.do_coagulation)
 
-        # atmospheric conditions
-        self.assertTrue(abs(scenario.temperature - input.temp) < 1e-12)
-        self.assertTrue(abs(scenario.pressure - input.press) < 1e-12)
-        self.assertTrue(abs(scenario.relative_humidity - input.RH_CLEA) < 1e-12)
-
-        # modal number concentrations
-        self.assertTrue(abs(scenario.size.modes[0].number - input.numc1) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[1].number - input.numc2) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[2].number - input.numc3) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[3].number - input.numc4) < 1e-12)
-
-        # accumulation mode species mass fractions
-        self.assertEqual('accumulation', scenario.size.modes[0].name)
-        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[0] - input.mfso41) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[1] - input.mfpom1) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[2] - input.mfsoa1) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[3] - input.mfbc1)  < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[4] - input.mfdst1) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[5] - input.mfncl1) < 1e-12)
-
-        # aitken mode species mass fractions
-        self.assertEqual('aitken', scenario.size.modes[1].name)
-        self.assertTrue(abs(scenario.size.modes[1].mass_fractions[0] - input.mfso42) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[1].mass_fractions[1] - input.mfsoa2) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[1].mass_fractions[2] - input.mfncl2) < 1e-12)
-
-        # coarse mode species mass fractions
-        self.assertEqual('coarse', scenario.size.modes[2].name)
-        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[0] - input.mfdst3) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[1] - input.mfncl3) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[2] - input.mfso43) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[3] - input.mfbc3)  < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[4] - input.mfpom3) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[5] - input.mfsoa3) < 1e-12)
-
-        # primary carbon species mass fractions
-        self.assertEqual('primary carbon', scenario.size.modes[3].name)
-        self.assertTrue(abs(scenario.size.modes[3].mass_fractions[0] - input.mfpom4) < 1e-12)
-        self.assertTrue(abs(scenario.size.modes[3].mass_fractions[1] - input.mfbc4)  < 1e-12)
+        # FIXME: more stuff vvv
 
     def test_create_partmc_inputs(self):
         processes = aerosol.AerosolProcesses(
@@ -169,60 +130,21 @@ class TestPartMCInput(unittest.TestCase):
         dt = 4.0
         nstep = 100
 
-        inputs = partmc.create_partmc_inputs(processes, self.ensemble, dt, nstep)
+        inputs = partmc.create_partmc_inputs('particle', processes, self.ensemble, dt, nstep)
         for i, input in enumerate(inputs):
             scenario = self.ensemble.member(i)
 
             # timestepping parameters
-            self.assertTrue(abs(dt - input.mam_dt) < 1e-12)
-            self.assertTrue(nstep, input.mam_nstep)
+            self.assertTrue(abs(dt - input.del_t) < 1e-12)
+            self.assertTrue(abs(nstep * dt - input.t_max) < 1e-12)
 
             # aerosol processes
-            self.assertFalse(input.mdo_gaschem)
-            self.assertFalse(input.mdo_gasaerexch)
-            self.assertFalse(input.mdo_rename)
-            self.assertFalse(input.mdo_newnuc)
-            self.assertTrue(True, input.mdo_coag)
+            self.assertFalse(input.do_mosaic)
+            self.assertFalse(input.do_nucleation)
+            self.assertFalse(input.do_condensation)
+            self.assertTrue(input.do_coagulation)
 
-            # atmospheric conditions
-            self.assertTrue(abs(scenario.temperature - input.temp) < 1e-12)
-            self.assertTrue(abs(scenario.pressure - input.press) < 1e-12)
-            self.assertTrue(abs(scenario.relative_humidity - input.RH_CLEA) < 1e-12)
-
-            # modal number concentrations
-            self.assertTrue(abs(scenario.size.modes[0].number - input.numc1) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[1].number - input.numc2) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[2].number - input.numc3) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[3].number - input.numc4) < 1e-12)
-
-            # accumulation mode species mass fractions
-            self.assertEqual('accumulation', scenario.size.modes[0].name)
-            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[0] - input.mfso41) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[1] - input.mfpom1) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[2] - input.mfsoa1) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[3] - input.mfbc1)  < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[4] - input.mfdst1) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[5] - input.mfncl1) < 1e-12)
-
-            # aitken mode species mass fractions
-            self.assertEqual('aitken', scenario.size.modes[1].name)
-            self.assertTrue(abs(scenario.size.modes[1].mass_fractions[0] - input.mfso42) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[1].mass_fractions[1] - input.mfsoa2) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[1].mass_fractions[2] - input.mfncl2) < 1e-12)
-
-            # coarse mode species mass fractions
-            self.assertEqual('coarse', scenario.size.modes[2].name)
-            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[0] - input.mfdst3) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[1] - input.mfncl3) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[2] - input.mfso43) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[3] - input.mfbc3)  < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[4] - input.mfpom3) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[5] - input.mfsoa3) < 1e-12)
-
-            # primary carbon species mass fractions
-            self.assertEqual('primary carbon', scenario.size.modes[3].name)
-            self.assertTrue(abs(scenario.size.modes[3].mass_fractions[0] - input.mfpom4) < 1e-12)
-            self.assertTrue(abs(scenario.size.modes[3].mass_fractions[1] - input.mfbc4)  < 1e-12)
+            # FIXME: more stuff vvv
 
     def test_write_files(self):
         processes = aerosol.AerosolProcesses(
@@ -232,11 +154,12 @@ class TestPartMCInput(unittest.TestCase):
         scenario = self.ensemble.member(0)
         dt = 4.0
         nstep = 100
-        input = partmc.create_partmc_input(processes, scenario, dt, nstep)
+        input = partmc.create_partmc_input('particle', processes, scenario, dt, nstep)
         prefix = 'partmc'
-        self.temp_dir = tempfile.TemporaryDirectory()
-        input.write_files(temp_dir.name, input_file)
+        temp_dir = tempfile.TemporaryDirectory()
+        input.write_files(temp_dir.name)
         self.assertTrue(os.path.exists(os.path.join(temp_dir.name, 'partmc.spec')))
+        temp_dir.close()
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_partmc.py
+++ b/test/test_partmc.py
@@ -36,6 +36,8 @@ class TestPartMCInput(unittest.TestCase):
         self.n = 100
         self.ensemble_spec = ppe.EnsembleSpecification(
             name = 'partmc_ensemble',
+            aerosols = (so4, pom, soa, bc, dst, ncl),
+            gases = (so2, h2so4, soag),
             size = aerosol.AerosolModalSizeDistribution(
                 modes = [
                     aerosol.AerosolModeDistribution(
@@ -89,6 +91,7 @@ class TestPartMCInput(unittest.TestCase):
                     ),
                 ],
             ),
+            gas_concs = (scipy.stats.loguniform(1e5, 1e6) for g in range(3)),
             flux = scipy.stats.loguniform(1e-2*1e-9, 1e1*1e-9),
             relative_humidity = scipy.stats.loguniform(1e-5, 0.99),
             temperature = scipy.stats.uniform(240, 310),

--- a/test/test_partmc.py
+++ b/test/test_partmc.py
@@ -1,0 +1,239 @@
+# unit tests for the ambrs.partmc package
+
+import ambrs.aerosol as aerosol
+import ambrs.gas as gas
+import ambrs.ppe as ppe
+from ambrs.scenario import Scenario
+import ambrs.partmc as partmc
+
+import math
+import numpy as np
+import os, os.path
+import scipy.stats
+import tempfile
+import unittest
+
+# relevant aerosol and gas species
+so4 = aerosol.AerosolSpecies(name='so4', molar_mass = 97.071)
+pom = aerosol.AerosolSpecies(name='pom', molar_mass = 12.01)
+soa = aerosol.AerosolSpecies(name='soa', molar_mass = 12.01)
+bc  = aerosol.AerosolSpecies(name='bc', molar_mass = 12.01)
+dst = aerosol.AerosolSpecies(name='dst', molar_mass = 135.065)
+ncl = aerosol.AerosolSpecies(name='ncl', molar_mass = 58.44)
+
+so2   = gas.GasSpecies(name='so2', molar_mass = 64.07)
+h2so4 = gas.GasSpecies(name='h2so4', molar_mass = 98.079)
+soag  = gas.GasSpecies(name='soag', molar_mass = 12.01)
+
+# reference pressure and height
+p0 = 101325 # [Pa]
+h0 = 500    # [m]
+
+class TestPartMCInput(unittest.TestCase):
+    """Unit tests for ambr.partmc.PartMCInput"""
+
+    def setUp(self):
+        self.n = 100
+        self.ensemble_spec = ppe.EnsembleSpecification(
+            name = 'partmc_ensemble',
+            size = aerosol.AerosolModalSizeDistribution(
+                modes = [
+                    aerosol.AerosolModeDistribution(
+                        name = "accumulation",
+                        species = [so4, pom, soa, bc, dst, ncl],
+                        number = scipy.stats.loguniform(3e7, 2e12),
+                        geom_mean_diam = scipy.stats.loguniform(0.5e-7, 1.1e-7),
+                        mass_fractions = [
+                            scipy.stats.uniform(0, 1), # so4
+                            scipy.stats.uniform(0, 1), # pom
+                            scipy.stats.uniform(0, 1), # soa
+                            scipy.stats.uniform(0, 1), # bc
+                            scipy.stats.uniform(0, 1), # dst
+                            scipy.stats.uniform(0, 1), # ncl
+                        ],
+                    ),
+                    aerosol.AerosolModeDistribution(
+                        name = "aitken",
+                        species = [so4, soa, ncl],
+                        number = scipy.stats.loguniform(3e7, 2e12),
+                        geom_mean_diam = scipy.stats.loguniform(0.5e-8, 3e-8),
+                        mass_fractions = [
+                            scipy.stats.uniform(0, 1), # so4
+                            scipy.stats.uniform(0, 1), # soa
+                            scipy.stats.uniform(0, 1), # ncl
+                        ],
+                    ),
+                    aerosol.AerosolModeDistribution(
+                        name = "coarse",
+                        species = [dst, ncl, so4, bc, pom, soa],
+                        number = scipy.stats.loguniform(3e7, 2e12),
+                        geom_mean_diam = scipy.stats.loguniform(1e-6, 2e-6),
+                        mass_fractions = [
+                            scipy.stats.uniform(0, 1), # dst
+                            scipy.stats.uniform(0, 1), # ncl
+                            scipy.stats.uniform(0, 1), # so4
+                            scipy.stats.uniform(0, 1), # bc
+                            scipy.stats.uniform(0, 1), # pom
+                            scipy.stats.uniform(0, 1), # soa
+                        ],
+                    ),
+                    aerosol.AerosolModeDistribution(
+                        name = "primary carbon",
+                        species = [pom, bc],
+                        number = scipy.stats.loguniform(3e7, 2e12),
+                        geom_mean_diam = scipy.stats.loguniform(1e-8, 6e-8),
+                        mass_fractions = [
+                            scipy.stats.uniform(0, 1), # pom
+                            scipy.stats.uniform(0, 1), # bc
+                        ],
+                    ),
+                ],
+            ),
+            flux = scipy.stats.loguniform(1e-2*1e-9, 1e1*1e-9),
+            relative_humidity = scipy.stats.loguniform(1e-5, 0.99),
+            temperature = scipy.stats.uniform(240, 310),
+            pressure = p0,
+            height = h0,
+        )
+        self.ensemble = ppe.sample(self.ensemble_spec, self.n)
+
+    def test_create_partmc_input(self):
+        processes = aerosol.AerosolProcesses(
+            aging = True,
+            coagulation = True,
+        )
+        scenario = self.ensemble.member(0)
+        dt = 4.0
+        nstep = 100
+        input = partmc.create_partmc_input(processes, scenario, dt, nstep)
+
+        # timestepping parameters
+        self.assertTrue(abs(dt - input.mam_dt) < 1e-12)
+        self.assertTrue(nstep, input.mam_nstep)
+
+        # aerosol processes
+        self.assertFalse(input.mdo_gaschem)
+        self.assertFalse(input.mdo_gasaerexch)
+        self.assertFalse(input.mdo_rename)
+        self.assertFalse(input.mdo_newnuc)
+        self.assertTrue(input.mdo_coag)
+
+        # atmospheric conditions
+        self.assertTrue(abs(scenario.temperature - input.temp) < 1e-12)
+        self.assertTrue(abs(scenario.pressure - input.press) < 1e-12)
+        self.assertTrue(abs(scenario.relative_humidity - input.RH_CLEA) < 1e-12)
+
+        # modal number concentrations
+        self.assertTrue(abs(scenario.size.modes[0].number - input.numc1) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[1].number - input.numc2) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].number - input.numc3) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[3].number - input.numc4) < 1e-12)
+
+        # accumulation mode species mass fractions
+        self.assertEqual('accumulation', scenario.size.modes[0].name)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[0] - input.mfso41) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[1] - input.mfpom1) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[2] - input.mfsoa1) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[3] - input.mfbc1)  < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[4] - input.mfdst1) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[0].mass_fractions[5] - input.mfncl1) < 1e-12)
+
+        # aitken mode species mass fractions
+        self.assertEqual('aitken', scenario.size.modes[1].name)
+        self.assertTrue(abs(scenario.size.modes[1].mass_fractions[0] - input.mfso42) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[1].mass_fractions[1] - input.mfsoa2) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[1].mass_fractions[2] - input.mfncl2) < 1e-12)
+
+        # coarse mode species mass fractions
+        self.assertEqual('coarse', scenario.size.modes[2].name)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[0] - input.mfdst3) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[1] - input.mfncl3) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[2] - input.mfso43) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[3] - input.mfbc3)  < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[4] - input.mfpom3) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[2].mass_fractions[5] - input.mfsoa3) < 1e-12)
+
+        # primary carbon species mass fractions
+        self.assertEqual('primary carbon', scenario.size.modes[3].name)
+        self.assertTrue(abs(scenario.size.modes[3].mass_fractions[0] - input.mfpom4) < 1e-12)
+        self.assertTrue(abs(scenario.size.modes[3].mass_fractions[1] - input.mfbc4)  < 1e-12)
+
+    def test_create_partmc_inputs(self):
+        processes = aerosol.AerosolProcesses(
+            aging = True,
+            coagulation = True,
+        )
+        dt = 4.0
+        nstep = 100
+
+        inputs = partmc.create_partmc_inputs(processes, self.ensemble, dt, nstep)
+        for i, input in enumerate(inputs):
+            scenario = self.ensemble.member(i)
+
+            # timestepping parameters
+            self.assertTrue(abs(dt - input.mam_dt) < 1e-12)
+            self.assertTrue(nstep, input.mam_nstep)
+
+            # aerosol processes
+            self.assertFalse(input.mdo_gaschem)
+            self.assertFalse(input.mdo_gasaerexch)
+            self.assertFalse(input.mdo_rename)
+            self.assertFalse(input.mdo_newnuc)
+            self.assertTrue(True, input.mdo_coag)
+
+            # atmospheric conditions
+            self.assertTrue(abs(scenario.temperature - input.temp) < 1e-12)
+            self.assertTrue(abs(scenario.pressure - input.press) < 1e-12)
+            self.assertTrue(abs(scenario.relative_humidity - input.RH_CLEA) < 1e-12)
+
+            # modal number concentrations
+            self.assertTrue(abs(scenario.size.modes[0].number - input.numc1) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[1].number - input.numc2) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].number - input.numc3) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[3].number - input.numc4) < 1e-12)
+
+            # accumulation mode species mass fractions
+            self.assertEqual('accumulation', scenario.size.modes[0].name)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[0] - input.mfso41) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[1] - input.mfpom1) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[2] - input.mfsoa1) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[3] - input.mfbc1)  < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[4] - input.mfdst1) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[0].mass_fractions[5] - input.mfncl1) < 1e-12)
+
+            # aitken mode species mass fractions
+            self.assertEqual('aitken', scenario.size.modes[1].name)
+            self.assertTrue(abs(scenario.size.modes[1].mass_fractions[0] - input.mfso42) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[1].mass_fractions[1] - input.mfsoa2) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[1].mass_fractions[2] - input.mfncl2) < 1e-12)
+
+            # coarse mode species mass fractions
+            self.assertEqual('coarse', scenario.size.modes[2].name)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[0] - input.mfdst3) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[1] - input.mfncl3) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[2] - input.mfso43) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[3] - input.mfbc3)  < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[4] - input.mfpom3) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[2].mass_fractions[5] - input.mfsoa3) < 1e-12)
+
+            # primary carbon species mass fractions
+            self.assertEqual('primary carbon', scenario.size.modes[3].name)
+            self.assertTrue(abs(scenario.size.modes[3].mass_fractions[0] - input.mfpom4) < 1e-12)
+            self.assertTrue(abs(scenario.size.modes[3].mass_fractions[1] - input.mfbc4)  < 1e-12)
+
+    def test_write_files(self):
+        processes = aerosol.AerosolProcesses(
+            aging = True,
+            coagulation = True,
+        )
+        scenario = self.ensemble.member(0)
+        dt = 4.0
+        nstep = 100
+        input = partmc.create_partmc_input(processes, scenario, dt, nstep)
+        prefix = 'partmc'
+        self.temp_dir = tempfile.TemporaryDirectory()
+        input.write_files(temp_dir.name, input_file)
+        self.assertTrue(os.path.exists(os.path.join(temp_dir.name, 'partmc.spec')))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_ppe.py
+++ b/test/test_ppe.py
@@ -21,6 +21,10 @@ so2   = gas.GasSpecies(name='so2', molar_mass = 64.07)
 h2so4 = gas.GasSpecies(name='h2so4', molar_mass = 98.079)
 soag  = gas.GasSpecies(name='soag', molar_mass = 12.01)
 
+# reference pressure and height
+p0 = 101325 # [Pa]
+h0 = 500    # [m]
+
 class TestEnsemble(unittest.TestCase):
     """Unit tests for ambr.ppe.Ensemble"""
 
@@ -41,6 +45,8 @@ class TestEnsemble(unittest.TestCase):
             flux = 0.0,
             relative_humidity = 0.5,
             temperature = 298.0,
+            pressure = p0,
+            height = h0,
         )
         self.ensemble = ppe.Ensemble(
             size = aerosol.AerosolModalSizePopulation(
@@ -61,6 +67,8 @@ class TestEnsemble(unittest.TestCase):
             flux = np.full(self.n, self.ref_scenario.flux),
             relative_humidity = np.full(self.n, self.ref_scenario.relative_humidity),
             temperature = np.full(self.n, self.ref_scenario.temperature),
+            pressure = p0,
+            height = h0,
         )
 
     def test_len(self):
@@ -142,6 +150,8 @@ class TestSampling(unittest.TestCase):
             flux = scipy.stats.loguniform(1e-2*1e-9, 1e1*1e-9),
             relative_humidity = scipy.stats.loguniform(1e-5, 0.99),
             temperature = scipy.stats.uniform(240, 310),
+            pressure = p0,
+            height = h0,
         )
 
     def test_sample(self):

--- a/test/test_ppe.py
+++ b/test/test_ppe.py
@@ -31,6 +31,8 @@ class TestEnsemble(unittest.TestCase):
     def setUp(self):
         self.n = 100
         self.ref_scenario = Scenario(
+            aerosols = (so4, soa, ncl),
+            gases = (so2, h2so4, soag),
             size = aerosol.AerosolModalSizeState(
                 modes = (
                     aerosol.AerosolModeState(
@@ -42,6 +44,7 @@ class TestEnsemble(unittest.TestCase):
                     ),
                 ),
             ),
+            gas_concs = (1e4, 1e5, 1e6),
             flux = 0.0,
             relative_humidity = 0.5,
             temperature = 298.0,
@@ -49,6 +52,8 @@ class TestEnsemble(unittest.TestCase):
             height = h0,
         )
         self.ensemble = ppe.Ensemble(
+            aerosols = (so4, soa, ncl),
+            gases = (so2, h2so4, soag),
             size = aerosol.AerosolModalSizePopulation(
                 modes = (
                     aerosol.AerosolModePopulation(
@@ -64,6 +69,7 @@ class TestEnsemble(unittest.TestCase):
                     ),
                 ),
             ),
+            gas_concs = tuple([np.full(self.n, gas_conc) for gas_conc in self.ref_scenario.gas_concs]),
             flux = np.full(self.n, self.ref_scenario.flux),
             relative_humidity = np.full(self.n, self.ref_scenario.relative_humidity),
             temperature = np.full(self.n, self.ref_scenario.temperature),
@@ -94,6 +100,8 @@ class TestSampling(unittest.TestCase):
         self.n = 100
         self.ensemble_spec = ppe.EnsembleSpecification(
             name = 'mam4_ensemble',
+            aerosols = (so4, pom, soa, bc, dst, ncl),
+            gases = (so2, h2so4, soag),
             size = aerosol.AerosolModalSizeDistribution(
                 modes = [
                     aerosol.AerosolModeDistribution(
@@ -147,6 +155,7 @@ class TestSampling(unittest.TestCase):
                     ),
                 ],
             ),
+            gas_concs = tuple([scipy.stats.uniform(1e5, 1e6) for g in range(3)]),
             flux = scipy.stats.loguniform(1e-2*1e-9, 1e1*1e-9),
             relative_humidity = scipy.stats.loguniform(1e-5, 0.99),
             temperature = scipy.stats.uniform(240, 310),


### PR DESCRIPTION
This pull request (PR) brings in data structures that hold all the information needed to generate input files for MAM4 and particle-based PartMC (particle-based simulations only). These data structures are not finalized, and some issues remain, but this is what I could do without input from the rest of the team.

I've also added some metadata related to aerosol and gas species present in ensembles/scenarios, for clarity, and to help with input parameter validation in the future.

With these changes, most of the groundwork is laid for `ambrs`. My next steps are to devise some simple setups for running ensembles. I think it would be helpful to have the team meet and discuss specifically the first set of ensemble runs we'd like to do to demonstrate the capabilities of `ambr`. I can work on the ensemble running machinery concurrently, and the resulting discussion will likely refine the input data structures in this PR.

@bnmurphy and @nriemer , I've added you as reviewers to invite you to look at what I've been doing. I know everyone's busy these days, so feel free to catch up with me whenever it's convenient, but if you do have any questions about anything, hit me up or leave an in-line comment on the "Files changed" tab.