### PR TITLE
Update mam4.py

### DIFF
--- a/ambrs/mam4.py
+++ b/ambrs/mam4.py
@@ -153,8 +153,8 @@ class GasMixingRatios:
         if ih2so4 == -1:
             raise ValueError("H2SO4 gas not found in gas species")
         isoag = GasSpecies.find(scenario.gases, 'soag')
-        self.SO2 = scenario.gas_concs[iso2],
-        self.H2SO4 = scenario.gas_concs[ih2so4],
+        self.SO2 = scenario.gas_concs[iso2]
+        self.H2SO4 = scenario.gas_concs[ih2so4]
         self.SOAG = 0.0 if isoag == -1 else scenario.gas_concs[isoag]
 
 


### PR DESCRIPTION
removed commas at end of lines 156 and 157. It was turning self.SO2 and self.H2SO4 into tuples. Here are the relevant lines from the namelist:
  qso2           = (np.float64(241216.89736780812),),
  qh2so4         = (np.float64(340676.3401868347),),

self.SO2 = scenario.gas_concs[iso2], --> self.SO2 = scenario.gas_concs[iso2]

self.H2SO4 = scenario.gas_concs[ih2so4], --> self.H2SO4 = scenario.gas_concs[ih2so4]