### PR TITLE
modified partmc input generation to include "do_tchem no\n" line

### DIFF
--- a/ambrs/partmc.py
+++ b/ambrs/partmc.py
@@ -342,6 +342,7 @@ class AerosolModel(BaseAerosolModel):
             spec_content += 'do_camp_chem no\n'
         spec_content += '\n'
 
+        spec_content += 'do_tchem no\n'
         # gas data
         if not self.processes.do_camp_chem:
             spec_content += 'gas_data gas_data.dat\n'


### PR DESCRIPTION
Not sure this is the correct form, but I'm merging a small modification to this branch for now. With the new version of PartMC, we need an additional line in the spec file. I'm not sure why I didn't catch this in the previous check...